### PR TITLE
Posicion inicial de panel info de animales  debajo del plano

### DIFF
--- a/OsoConPanel/OsoConPanel/Assets/MenuInteracciones.cs
+++ b/OsoConPanel/OsoConPanel/Assets/MenuInteracciones.cs
@@ -25,7 +25,7 @@ public class MenuInteracciones : MonoBehaviour {
     public Camera myCamera;
     public Transform animTransform;
 
-    private int interaccion;
+    private int interaccion = -1;
     private bool init = false;
     
     void Start () {
@@ -69,7 +69,24 @@ public class MenuInteracciones : MonoBehaviour {
                 AnimacionesAnimales.mostrandoInformacionAnimal = animator.name;
             }
             else if (interaccion == AnimacionesAnimales.ACCION_VER_INFO)
-            {   
+            {
+                //bInfo y bVolver estan debajo del plano al cargar la escena
+                if (bInfo.transform.localPosition.y == -1000)
+                {
+                    bInfo.transform.localPosition = new Vector3(
+                        bInfo.transform.localPosition.x,
+                        37,
+                        bInfo.transform.localPosition.z);
+                }
+
+                if (bVolver.transform.localPosition.y == -1000)
+                {
+                    bVolver.transform.localPosition = new Vector3(
+                        bVolver.transform.localPosition.x,
+                        -120,
+                        bVolver.transform.localPosition.z);
+                }
+ 
                 bInfo.SetActive(true);
                 bVolver.SetActive(true);
                 interaccion = -1;

--- a/OsoConPanel/OsoConPanel/Assets/Scenes/Bosque 2.unity
+++ b/OsoConPanel/OsoConPanel/Assets/Scenes/Bosque 2.unity
@@ -48833,7 +48833,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: -181.129, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 37}
+  m_AnchoredPosition: {x: -5, y: -1000}
   m_SizeDelta: {x: 600, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1300754442
@@ -53526,7 +53526,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: -180.84999, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -120}
+  m_AnchoredPosition: {x: 0, y: -1000}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1418235513


### PR DESCRIPTION
-Se setea la posicion en y del bInfo y bVolver en -1000 al iniciar la escena. Al seleccionar la opción "Ver información" del menú de interacción se setean las posiciones correctas